### PR TITLE
fix emulator launch

### DIFF
--- a/src/main/java/functional/tests/core/mobile/device/android/Adb.java
+++ b/src/main/java/functional/tests/core/mobile/device/android/Adb.java
@@ -583,9 +583,17 @@ public class Adb {
     public String getAvdName(String deviceId) throws DeviceException {
         String port = deviceId.split("-")[1];
         String name = "";
+        String avd = "";
         try {
             String result = OSUtils.runProcess("ps aux | grep qemu | grep " + port);
-            String avd = result.split("-avd")[1].split(" ")[1].trim();
+            if (result.contains("-avd")) {
+                avd = result.split("-avd")[1].split(" ")[1].trim();
+            } else {
+                result = OSUtils.runProcess("ps aux | grep qemu");
+                if (result.contains("-avd")) {
+                    avd = result.split("-avd")[1].split("\\s+")[1].trim();
+                }
+            }
             name = avd;
         } catch (Exception ex) {
             LOGGER_BASE.error("Failed to get name of " + deviceId);

--- a/src/main/java/functional/tests/core/mobile/device/android/AndroidDevice.java
+++ b/src/main/java/functional/tests/core/mobile/device/android/AndroidDevice.java
@@ -444,7 +444,9 @@ public class AndroidDevice implements IDevice {
         }
 
         // Kill all simulators not matching framework convention
-        this.stopWrongPortEmulators();
+        if (!this.settings.debug) {
+            this.stopWrongPortEmulators();
+        }
 
         // Kill simulators and web driver sessions used more than 90 min
         this.adb.stopUsedEmulators(60);

--- a/src/main/java/functional/tests/core/settings/Settings.java
+++ b/src/main/java/functional/tests/core/settings/Settings.java
@@ -99,7 +99,7 @@ public class Settings {
                 new Boolean(this.properties.getProperty("logImageVerificationStatus")) : false;
 
         // Set debug
-        this.debug = Boolean.valueOf(OSUtils.getEnvironmentVariable(DEBUG_ENVIRONMENT_VARIABLE, "False")) ||
+        this.debug = this.propertyToBoolean("debug", false) || Boolean.valueOf(OSUtils.getEnvironmentVariable(DEBUG_ENVIRONMENT_VARIABLE, "False")) ||
                 java.lang.management.ManagementFactory
                         .getRuntimeMXBean().getInputArguments().toString().indexOf("jdwp") >= 0;
 


### PR DESCRIPTION
when emulator is started from Android studio we are unable to get its name and test execution fails.