### PR TITLE
fix: use random adbPort

### DIFF
--- a/src/main/java/functional/tests/core/mobile/appium/Capabilities.java
+++ b/src/main/java/functional/tests/core/mobile/appium/Capabilities.java
@@ -77,6 +77,7 @@ public class Capabilities {
             capabilities.setCapability(AndroidMobileCapabilityType.APP_WAIT_ACTIVITY, settings.android.appWaitActivity);
             capabilities.setCapability(AndroidMobileCapabilityType.APP_WAIT_PACKAGE, settings.android.appWaitPackage);
             capabilities.setCapability(AndroidMobileCapabilityType.NO_SIGN, true);
+            capabilities.setCapability(AndroidMobileCapabilityType.ADB_PORT, OSUtils.getFreePort(5037, 5137));
             if (settings.automationName.equalsIgnoreCase("UIAutomator2")) {
                 int port = OSUtils.getFreePort(8201, 8300);
                 capabilities.setCapability("systemPort", port);


### PR DESCRIPTION
We encounter a lot of cases when adb hangup on CI (mostly on nsbuildlin03) where a lot of emulators are running in parrallel.

I guess we have too many adb sessions on same port and that is causing the problem.
This is attempt to use different adbPort for each session.